### PR TITLE
board: Add build flag to include Magisk at build-time

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -24,7 +24,11 @@ PRODUCT_PLATFORM := exynos9820
 TARGET_OTA_ASSERT_DEVICE := beyond2,beyond2lte,beyond2ltexx
 
 ### KERNEL
-TARGET_KERNEL_CONFIG := exynos9820-beyond2lte_defconfig
+ifeq ($(WITH_MAGISK),true)
+  TARGET_KERNEL_CONFIG := exynos9820-beyond2lte_magisk_defconfig
+else
+  TARGET_KERNEL_CONFIG := exynos9820-beyond2lte_defconfig
+endif
 
 ### PARTITIONS
 # /proc/partitions shows the size in 1024-byte blocks


### PR DESCRIPTION
Since we currently cannot override kernel configs from device trees, we have two defconfigs per device:
 * exynos9820-beyond[0|1|2]lte_defconfig without Magisk
 * exynos9820-beyond[0|1|2]lte_magisk_defconfig without Magisk

This way, we can choose a defconfig dynamically based on a build flag.